### PR TITLE
Fix flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "hex",
  "http 1.2.0",
  "insta",
+ "insta-cmd",
  "reqwest",
  "sha2",
  "tokio",
@@ -1215,7 +1216,19 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "serde",
  "similar",
+]
+
+[[package]]
+name = "insta-cmd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+dependencies = [
+ "insta",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ http = "1.2.0"
 reqwest = "0.12.9"
 sha2 = "0.10.8"
 tokio = { version = "1.42.0", features = ["full"] }
+chrono = "0.4.39"
 
 [profile.release]
 strip = true 
 lto = true
 
 [dev-dependencies]
-chrono = "0.4.39"
 insta = "1.41.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ lto = true
 
 [dev-dependencies]
 insta = "1.41.1"
+insta-cmd = "0.6.0"


### PR DESCRIPTION
Some tests failed when running by `nextest` because of order of headers.